### PR TITLE
Add a default to currency handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,5 +41,5 @@
     "test": "jest",
     "prepublish": "yarn bundle"
   },
-  "version": "1.4.0"
+  "version": "1.4.1"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "dist/spices-basil-i18n.min.js.js",
   "module": "dist/spices-basil-i18n.esm.min.js",
-  "name": "@spices/basil-i18n",
+  "name": "@spices/basil-ic-i18n",
   "nodemonConfig": {
     "exec": "yarn bundle",
     "watch": "src"
@@ -28,11 +28,11 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://npm.infinity-commerce.io/"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:alexandremasy/spices-basil-i18n.git"
+    "url": "git+ssh://git@github.com:vlntngrgr/spices-basil-i18n.git"
   },
   "scripts": {
     "bundle": "rollup -c",
@@ -41,5 +41,5 @@
     "test": "jest",
     "prepublish": "yarn bundle"
   },
-  "version": "1.3.0"
+  "version": "1.4.0"
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "main": "dist/spices-basil-i18n.min.js.js",
   "module": "dist/spices-basil-i18n.esm.min.js",
-  "name": "@spices/basil-ic-i18n",
+  "name": "@spices/basil-i18n",
   "nodemonConfig": {
     "exec": "yarn bundle",
     "watch": "src"
@@ -28,11 +28,11 @@
   },
   "publishConfig": {
     "access": "public",
-    "registry": "https://npm.infinity-commerce.io/"
+    "registry": "https://registry.npmjs.org/"
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com:vlntngrgr/spices-basil-i18n.git"
+    "url": "git+ssh://git@github.com:alexandremasy/spices-basil-i18n.git"
   },
   "scripts": {
     "bundle": "rollup -c",

--- a/src/core/locale.js
+++ b/src/core/locale.js
@@ -1,3 +1,4 @@
+import Currencies from '../vos/number-currencies'
 import Locale from '../vos/locale'
 import Priority from '../vos/priority'
 
@@ -39,7 +40,12 @@ export default class i18nLocaleController {
     return this._currency
   }
   set currency(value){
-    this._currency = value
+    let d = [
+      Currencies.getByName(value),
+      Currencies.getByAlpha(value),
+      Currencies.getByNumeric(value),
+    ].find(d => !this._parent.isNil(d))
+    this._currency = Currencies.isValid(d) ? d : null
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/core/locale.js
+++ b/src/core/locale.js
@@ -17,6 +17,7 @@ export default class i18nLocaleController {
    * @param {*} options 
    */
   constructor(basil, scope, options = {}){
+    this._currency = null
     this._options = options
     this._parent = basil
     this._scope = scope
@@ -25,6 +26,20 @@ export default class i18nLocaleController {
     this._locales = null
 
     this.evaluate()
+  }
+
+  ///////////////////////////////////////////////////////////////////////////////
+
+  /**
+   * @property {Object} currency
+   * @returns {Object}
+   * The currency to use
+   */
+   get currency(){
+    return this._currency
+  }
+  set currency(value){
+    this._currency = value
   }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/install.js
+++ b/src/install.js
@@ -56,6 +56,12 @@ export default {
       set: (value) => ctrl.locales = value
     })
 
+    Object.defineProperty(scope, 'defaultCurrency', {
+      enumerable: true,
+      get: () => ctrl.currency,
+      set: (value) => ctrl.currency = vos.Currencies.getByAlpha(value) 
+    })
+
     // Components
     if (!!basil.$vue){
       installComponent(basil.$vue)

--- a/src/install.js
+++ b/src/install.js
@@ -59,7 +59,7 @@ export default {
     Object.defineProperty(scope, 'defaultCurrency', {
       enumerable: true,
       get: () => ctrl.currency,
-      set: (value) => ctrl.currency = vos.Currencies.getByAlpha(value) 
+      set: (value) => ctrl.currency = value 
     })
 
     // Components

--- a/src/utils/currency.js
+++ b/src/utils/currency.js
@@ -8,7 +8,7 @@ export default (basil, scope) => {
   const currency = (value, options = {}) => {
     let { 
       compact = false, 
-      currency = Currencies.EURO, 
+      currency = basil.get(scope, 'defaultCurrency', Currencies.EURO),
       display = Formats.SYMBOL, 
       fraction = 2, 
       group = true, 
@@ -38,7 +38,7 @@ export default (basil, scope) => {
 
     // Invalid currency => EURO and replace with custom value
     if (!Currencies.isValid(currency)){
-      currency = Currencies.EURO
+      currency = basil.get(scope, 'defaultCurrency', Currencies.EURO)
     }
 
     // Display validation


### PR DESCRIPTION
I needed it fast, so i have duplicated this repo.
Here is my proposal:
When I change the language, I would like to have a default currency used. Website using the USD will non stop have to pass the options.currency to the 'currency' function, but the fact is that I want to use a default currency in my app. 

There is a fallback on the EURO currency, and the behavior is the same as it used to be, just the default is not only euro, but can be set at the change of the language (for example with the i18n vuejs plugin: 
`this.$basil.i18n.defaultCurrency = this.i18n.getNumberFormat(this.i18n.locale).currency.currency` 